### PR TITLE
Improve README with TSLint migration info

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ promise-must-complete
 use-primitive-type
 ```
 
-This list has been produced following this steps:
+This list has been produced following these steps:
 1. Follow [TSLint to ESLint migration guide](https://code.visualstudio.com/api/advanced-topics/tslint-eslint-migration) on the project [io-backend](https://github.com/pagopa/io-backend)
 2. Running `npx tslint-to-eslint-config` that produces a list of TSLint rules not available for ESLint (77 rules at the moment)
 3. Manually check each one for an alternative ESLint rules/plugins

--- a/README.md
+++ b/README.md
@@ -8,7 +8,47 @@ This package provide the following ESLint custom rules for Typescript projects.
 
 This repository replace [italia-tslint-rules](https://github.com/pagopa/io-tslint-rules) after TSLint deprecation.
 
+The following TSLint rules (included inside `italia-tslint-rules`) are not supported for eslint at the moment and are missing in this package:
+```
+bool-param-default
+max-union-size
+no-accessor-field-mismatch
+no-array-delete // Mitigated by no-delete
+no-case-with-or
+no-dead-store
+no-duplicate-in-composite
+no-empty-array
+no-extra-semicolon // Mitigated by prettier
+no-empty-destructuring // Mititgated by no-empty-pattern
+no-gratuitous-expressions
+no-hardcoded-credentials
+no-ignored-initial-value // Mitigated by no-param-reassign, no-let
+no-in-misuse
+no-inferred-empty-object-type
+no-invalid-await // Mititgated by await-thenable
+no-invariant-return
+no-misleading-array-reverse // Mitigated by immutable-data
+no-misspelled-operator // Mitigated by prettier
+no-nested-switch
+no-nested-template-literals
+no-statements-same-line // Mitigated by prettier
+no-try-promise
+no-tslint-disable-all
+no-unconditional-jump
+no-undefined-argument
+no-unenclosed-multiline-block // Mitigated by prettier
+no-unthrown-error
+no-unused-array // Mitigated by no-unused-vars
+no-useless-increment
+no-useless-intersection
+prefer-promise-shorthand
+promise-must-complete
+use-primitive-type
+```
+
 ## Usage
+
+### Installation and Configuration
 
 To use this package install as devDependecy inside any typescript project with
 
@@ -29,11 +69,27 @@ module.exports = {
 }
 ```
 
-Add inside the `package.json` file a `lint` script as:
+Add inside the `package.json` file a `lint` and optionally a `lint-autofix` script as:
 
 ```
 "scripts": {
   "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx",
+  "lint-autofix": "eslint . -c .eslintrc.js --ext .ts,.tsx --fix",
   ...
 }
 ```
+
+### Migration from TSLint
+
+Remove from the `package.json` every tslint reference:
+
+- `tslint`
+- `italia-tslint-rules`
+
+Replace all the `// tslint:disable-next-line` with the proper `// eslint-disable-next-line` comment. If are present some `// tslint:disable` replace it with `/* eslint-disable */` at the top of the file.
+
+If you need to disable ESLint for some files create `.eslintignore` file with the list of folders or files that must be excluded from lint process. Copy the exclusion from `tslint.json` `linterOptions.exclude`
+
+Delete all tslint related files (es. `tslint.json`).
+
+Run `yarn lint-autofix` to refactorize the code automatically with all the auto-fixable ESLint rules.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ promise-must-complete
 use-primitive-type
 ```
 
+This list has been produced following this steps:
+1. Follow [TSLint to ESLint migration guide](https://code.visualstudio.com/api/advanced-topics/tslint-eslint-migration) on the project [io-backend](https://github.com/pagopa/io-backend)
+2. Running `npx tslint-to-eslint-config` that produces a list of TSLint rules not available for ESLint (77 rules at the moment)
+3. Manually check each one for an alternative ESLint rules/plugins
+4. Verify each alternative ESLint rule/plugin on a testing file
 ## Usage
 
 ### Installation and Configuration


### PR DESCRIPTION
#### List of Changes
Add migration section inside README

#### Motivation and Context
To give more detailed information above migration from TSLint and `italia-tslint-rules` to ESLint a new section was added with this PR inside the README.
The README now includes the list of rules present into `italia-tslint-rules` and missing inside `@pagopa/eslint-config`.

#### How Has This Been Tested?
No tests needed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.

#### Question:
Can we enable `eslint` even on `.test.ts` files? So we could have the same code style restrictions on tests.