### PR TITLE
Fix no-shadow false positive on enum

### DIFF
--- a/strong.js
+++ b/strong.js
@@ -74,12 +74,7 @@ module.exports = {
     "jsdoc/check-indentation": "error",
     "jsdoc/newline-after-description": "error",
     "prefer-arrow/prefer-arrow-functions": "error",
-    "no-shadow": [
-        "error",
-        {
-            "hoist": "all"
-        }
-    ],
+    "no-shadow": "off",
     "no-invalid-this": "error",
     "id-match": "error",
     "constructor-super": "error",
@@ -87,6 +82,12 @@ module.exports = {
     "@typescript-eslint/explicit-function-return-type": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/no-shadow": [
+        "error",
+        {
+            "hoist": "all"
+        }
+    ],
     "sort-keys": "error",
     "extra-rules/no-commented-out-code": "error",
     "no-useless-return": "error",


### PR DESCRIPTION
On `enum` the default eslint `no-shadow` rules return a false positive.
`no-shadow` rule is disabled in favour of `@typescript-eslint/no-shadow`