### PR TITLE
Add more specific naming rules

### DIFF
--- a/strong.js
+++ b/strong.js
@@ -46,7 +46,29 @@ module.exports = {
         }
     ],
     "@typescript-eslint/member-ordering": "error",
-    "@typescript-eslint/naming-convention": "error",
+    "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          selector: "variable",
+          format: ["PascalCase", "camelCase", "UPPER_CASE"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allow"
+        },
+        {
+          selector: "typeLike",
+          format: ["PascalCase"]
+        },
+        {
+          selector: "property",
+          format: ["PascalCase", "camelCase", "UPPER_CASE", "snake_case"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "forbid"
+        },
+        {
+          selector: "interface",
+          format: ["PascalCase"],
+          prefix: ["I"]
+        },
     "@typescript-eslint/no-use-before-define": "error",
     "@typescript-eslint/prefer-for-of": "error",
     "@typescript-eslint/prefer-namespace-keyword": "error",


### PR DESCRIPTION
We refine `@typescript-eslint/naming-convention` so that it will cope with our current codebase standards. For further explanation, see [docs](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md).