### PR TITLE
Remove jsdocs indentation

### DIFF
--- a/strong.js
+++ b/strong.js
@@ -1,49 +1,44 @@
 /* eslint-disable */
 module.exports = {
   extends: "./recommended.js",
-  plugins: [
-    "eslint-plugin-jsdoc",
-    "eslint-plugin-prefer-arrow",
-    "extra-rules",
-    "fp"
-  ],
+  plugins: ["eslint-plugin-jsdoc", "eslint-plugin-prefer-arrow", "extra-rules", "fp"],
   rules: {
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/ban-types": [
       "error",
       {
-          "types": {
-              "Object": {
-                  "message": "Avoid using the `Object` type. Did you mean `object`?"
-              },
-              "Function": {
-                  "message": "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."
-              },
-              "Boolean": {
-                  "message": "Avoid using the `Boolean` type. Did you mean `boolean`?"
-              },
-              "Number": {
-                  "message": "Avoid using the `Number` type. Did you mean `number`?"
-              },
-              "String": {
-                  "message": "Avoid using the `String` type. Did you mean `string`?"
-              },
-              "Symbol": {
-                  "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
-              }
-          }
-      }
+        types: {
+          Object: {
+            message: "Avoid using the `Object` type. Did you mean `object`?",
+          },
+          Function: {
+            message: "Avoid using the `Function` type. Prefer a specific function type, like `() => void`.",
+          },
+          Boolean: {
+            message: "Avoid using the `Boolean` type. Did you mean `boolean`?",
+          },
+          Number: {
+            message: "Avoid using the `Number` type. Did you mean `number`?",
+          },
+          String: {
+            message: "Avoid using the `String` type. Did you mean `string`?",
+          },
+          Symbol: {
+            message: "Avoid using the `Symbol` type. Did you mean `symbol`?",
+          },
+        },
+      },
     ],
     "@typescript-eslint/consistent-type-assertions": "error",
     "@typescript-eslint/consistent-type-definitions": "error",
     "@typescript-eslint/explicit-member-accessibility": [
-        "error",
-        {
-            "accessibility": "explicit",
-            "overrides": {
-                "constructors": "no-public"
-            }
-        }
+      "error",
+      {
+        accessibility: "explicit",
+        overrides: {
+          constructors: "no-public",
+        },
+      },
     ],
     "@typescript-eslint/member-ordering": "error",
     "@typescript-eslint/naming-convention": "error",
@@ -51,27 +46,26 @@ module.exports = {
     "@typescript-eslint/prefer-for-of": "error",
     "@typescript-eslint/prefer-namespace-keyword": "error",
     "@typescript-eslint/triple-slash-reference": [
-        "error",
-        {
-            "path": "always",
-            "types": "prefer-import",
-            "lib": "always"
-        }
+      "error",
+      {
+        path: "always",
+        types: "prefer-import",
+        lib: "always",
+      },
     ],
     "id-blacklist": [
-        "error",
-        "any",
-        "Number",
-        "number",
-        "String",
-        "string",
-        "Boolean",
-        "boolean",
-        "Undefined",
-        "undefined"
+      "error",
+      "any",
+      "Number",
+      "number",
+      "String",
+      "string",
+      "Boolean",
+      "boolean",
+      "Undefined",
+      "undefined",
     ],
     "jsdoc/check-alignment": "error",
-    "jsdoc/check-indentation": "error",
     "jsdoc/newline-after-description": "error",
     "prefer-arrow/prefer-arrow-functions": "error",
     "no-shadow": "off",
@@ -83,10 +77,10 @@ module.exports = {
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/prefer-optional-chain": "error",
     "@typescript-eslint/no-shadow": [
-        "error",
-        {
-            "hoist": "all"
-        }
+      "error",
+      {
+        hoist: "all",
+      },
     ],
     "sort-keys": "error",
     "extra-rules/no-commented-out-code": "error",
@@ -96,6 +90,6 @@ module.exports = {
     "default-case": "error",
     "functional/prefer-readonly-type": "error",
     "functional/no-method-signature": "error",
-    "fp/no-delete": "error"
+    "fp/no-delete": "error",
   },
 };

--- a/strong.js
+++ b/strong.js
@@ -1,44 +1,49 @@
 /* eslint-disable */
 module.exports = {
   extends: "./recommended.js",
-  plugins: ["eslint-plugin-jsdoc", "eslint-plugin-prefer-arrow", "extra-rules", "fp"],
+  plugins: [
+    "eslint-plugin-jsdoc",
+    "eslint-plugin-prefer-arrow",
+    "extra-rules",
+    "fp"
+  ],
   rules: {
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/ban-types": [
       "error",
       {
-        types: {
-          Object: {
-            message: "Avoid using the `Object` type. Did you mean `object`?",
-          },
-          Function: {
-            message: "Avoid using the `Function` type. Prefer a specific function type, like `() => void`.",
-          },
-          Boolean: {
-            message: "Avoid using the `Boolean` type. Did you mean `boolean`?",
-          },
-          Number: {
-            message: "Avoid using the `Number` type. Did you mean `number`?",
-          },
-          String: {
-            message: "Avoid using the `String` type. Did you mean `string`?",
-          },
-          Symbol: {
-            message: "Avoid using the `Symbol` type. Did you mean `symbol`?",
-          },
-        },
-      },
+          "types": {
+              "Object": {
+                  "message": "Avoid using the `Object` type. Did you mean `object`?"
+              },
+              "Function": {
+                  "message": "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."
+              },
+              "Boolean": {
+                  "message": "Avoid using the `Boolean` type. Did you mean `boolean`?"
+              },
+              "Number": {
+                  "message": "Avoid using the `Number` type. Did you mean `number`?"
+              },
+              "String": {
+                  "message": "Avoid using the `String` type. Did you mean `string`?"
+              },
+              "Symbol": {
+                  "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
+              }
+          }
+      }
     ],
     "@typescript-eslint/consistent-type-assertions": "error",
     "@typescript-eslint/consistent-type-definitions": "error",
     "@typescript-eslint/explicit-member-accessibility": [
-      "error",
-      {
-        accessibility: "explicit",
-        overrides: {
-          constructors: "no-public",
-        },
-      },
+        "error",
+        {
+            "accessibility": "explicit",
+            "overrides": {
+                "constructors": "no-public"
+            }
+        }
     ],
     "@typescript-eslint/member-ordering": "error",
     "@typescript-eslint/naming-convention": "error",
@@ -46,24 +51,24 @@ module.exports = {
     "@typescript-eslint/prefer-for-of": "error",
     "@typescript-eslint/prefer-namespace-keyword": "error",
     "@typescript-eslint/triple-slash-reference": [
-      "error",
-      {
-        path: "always",
-        types: "prefer-import",
-        lib: "always",
-      },
+        "error",
+        {
+            "path": "always",
+            "types": "prefer-import",
+            "lib": "always"
+        }
     ],
     "id-blacklist": [
-      "error",
-      "any",
-      "Number",
-      "number",
-      "String",
-      "string",
-      "Boolean",
-      "boolean",
-      "Undefined",
-      "undefined",
+        "error",
+        "any",
+        "Number",
+        "number",
+        "String",
+        "string",
+        "Boolean",
+        "boolean",
+        "Undefined",
+        "undefined"
     ],
     "jsdoc/check-alignment": "error",
     "jsdoc/newline-after-description": "error",
@@ -77,10 +82,10 @@ module.exports = {
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/prefer-optional-chain": "error",
     "@typescript-eslint/no-shadow": [
-      "error",
-      {
-        hoist: "all",
-      },
+        "error",
+        {
+            "hoist": "all"
+        }
     ],
     "sort-keys": "error",
     "extra-rules/no-commented-out-code": "error",
@@ -90,6 +95,6 @@ module.exports = {
     "default-case": "error",
     "functional/prefer-readonly-type": "error",
     "functional/no-method-signature": "error",
-    "fp/no-delete": "error",
+    "fp/no-delete": "error"
   },
 };


### PR DESCRIPTION
Do we want this rule? I argue we want be able to format jsdocs at convenience. Example: https://github.com/pagopa/io-functions-commons/blob/81a7cbaa79185452773a47ebd6c3d007c2a18657/src/utils/source_ip_check.ts#L102