### PR TITLE
[PROPOSAL] Remove `default-case` rule from strong ruleset

### DIFF
--- a/strong.js
+++ b/strong.js
@@ -115,7 +115,6 @@ module.exports = {
     "no-useless-return": "error",
     "no-multi-str": "error",
     "max-params": ["error", 5],
-    "default-case": "error",
     "functional/prefer-readonly-type": "error",
     "functional/no-method-signature": "error",
     "fp/no-delete": "error"


### PR DESCRIPTION
I found out `default-case` rule for `switch` statements can be annoying and useless in most (if not every) of our scenarios. 

In my opinion, case completeness is better handled by the Typescript compiler than by eslint. 

### Scenarios

#### Scenario: a complete switch
```ts
const completeSwitch = (arg: "foo" | "bar") => {
  switch(x){
    case "foo":
      return 1;
    case "bar":
      return 2;
  }
}
```

In the `completeSwitch` scenario a `default` case would be redundant, as every possible values of `arg` are already covered; still, the common _strong_ configuration will force you to declare a dummy `default`. 

####  Scenario: an incomplete switch
```ts
const incompleteSwitch = (arg: "foo" | "bar") => {
  //                      tsc would fail here ^^^                       
  switch(x){
    case "foo":
      return 1;
  }
}
```

In this scenario Typescript would fail to build because _"Function lacks ending return statement and return type does not include 'undefined'"_. Note that this is true **only if Typescript is running on strict mode**.

### Impact
By removing this rule, we're lowering control over two specific cases:
1. a value for which we don't trust its type
2. a project configured with `strict: false`

In my opinion, for cases of type (1) we should go at the root problem, incrementing input validation (an extensive use of codec will be good).
For the same reason we should not work with `strict: false` project; pragmatically, as it happens to handle a legacy project we are unable to convert to `strict: true`, for such projects we may want to explicitly add `default-case` directly in the project's local eslint configuration.


