### PR TITLE
[DISCUSSION] Enable `allowExpressions` rule

### DIFF
--- a/strong.js
+++ b/strong.js
@@ -101,7 +101,12 @@ module.exports = {
     "id-match": "error",
     "constructor-super": "error",
     "@typescript-eslint/no-namespace": "error",
-    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/explicit-function-return-type": [
+        "error",
+        {
+            allowExpressions: true
+        }
+    ],
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/prefer-optional-chain": "error",
     "@typescript-eslint/no-shadow": [


### PR DESCRIPTION
> ⚠️   Draft because not sure yet of which impact these changes will have to our codebase

I'm playing a bit with `@typescript-eslint/explicit-function-return-type` rule to find a proper configuration which will be ergonomic for our daily scenarios. Following [its documentation](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md), there are several parameters we can compose in order to tune its behaviour to fit our needs. 

### Expected behaviour
I'm not actually sure which result we want to achieve, so let's first pin some principles:
* we want functions to have an explicit signature
* we want trivial functions to use type inference (example: in `["one", "two"].map(e => e.length)` we don't need typings for `e => e.length`)
* we want to curry/compose functions at need without being too verbose

### Scenarios
One patter we use a lot is to have a higher-order function to serve as factory for another function ([example]( https://github.com/pagopa/io-functions-bonusapi/blob/0d8f0d1ddf86072b744ae9d5b1fbb7d4de218f97/ProcessRedeemedBonusMessageOrchestrator/handler.ts#L45)). 
Suppose we have:
```ts
const fn = (a: number) => (b: string) => b.repeat(a);
```

which would we considered correct?
```ts
// A
const fn = (a: number): (b: string) => string => 
  (b: string) => b.repeat(a);

// B
const fn = (a: number) => 
  (b: string): string => b.repeat(a);

// C
const fn = (a: number): (b: string) => string => 
  (b: string): string => b.repeat(a);

// D
const fn = (a: number) => (b: string) => b.repeat(a);
```

By using `allowExpressions: false` we are forcing `B`, however it may lead to [this unfortunate case](https://github.com/pagopa/io-functions-pushnotifications/blob/d0080c53bdaa60ffc8d409c7f66e5f8635b59c83/IsUserInActiveSubsetActivity/handler.ts#L37).